### PR TITLE
fix: align iceberg writer with storage semantics

### DIFF
--- a/crates/otlp2parquet-core/src/lib.rs
+++ b/crates/otlp2parquet-core/src/lib.rs
@@ -14,6 +14,7 @@ use anyhow::Result;
 use arrow::array::RecordBatch;
 
 pub mod otlp;
+pub mod parquet;
 pub mod schema;
 pub mod types;
 

--- a/crates/otlp2parquet-core/src/parquet/encoding.rs
+++ b/crates/otlp2parquet-core/src/parquet/encoding.rs
@@ -1,0 +1,238 @@
+use anyhow::{anyhow, Result};
+use arrow::{datatypes::SchemaRef, record_batch::RecordBatch};
+use parquet::arrow::ArrowWriter;
+use parquet::basic::ColumnOrder;
+use parquet::file::metadata::{
+    FileMetaData as PhysicalFileMetaData, ParquetMetaData, RowGroupMetaData,
+};
+use parquet::file::properties::{EnabledStatistics, WriterProperties};
+use parquet::format::{ColumnOrder as TColumnOrder, FileMetaData as ThriftFileMetaData, KeyValue};
+use parquet::schema::types::{self, SchemaDescriptor};
+use std::io::{self, Write};
+use std::sync::{Arc, OnceLock};
+
+use crate::types::Blake3Hash;
+
+#[cfg(target_arch = "wasm32")]
+use parquet::basic::Compression;
+#[cfg(not(target_arch = "wasm32"))]
+use parquet::basic::{Compression, ZstdLevel};
+
+const DEFAULT_ROW_GROUP_SIZE: usize = 32 * 1024;
+static ROW_GROUP_SIZE: OnceLock<usize> = OnceLock::new();
+
+/// Configure the global Parquet row group size used by Arrow writers.
+///
+/// Must be called before the first Parquet writer is created. Subsequent calls
+/// are ignored to preserve the existing writer properties cache.
+pub fn set_parquet_row_group_size(row_group_size: usize) {
+    if row_group_size == 0 {
+        return;
+    }
+
+    let _ = ROW_GROUP_SIZE.set(row_group_size);
+}
+
+fn configured_row_group_size() -> usize {
+    ROW_GROUP_SIZE
+        .get()
+        .copied()
+        .unwrap_or(DEFAULT_ROW_GROUP_SIZE)
+}
+
+struct HashingBuffer {
+    buffer: Vec<u8>,
+    hasher: blake3::Hasher,
+}
+
+impl HashingBuffer {
+    fn new() -> Self {
+        Self {
+            buffer: Vec::new(),
+            hasher: blake3::Hasher::new(),
+        }
+    }
+
+    fn finish(self) -> (Vec<u8>, Blake3Hash) {
+        let hash = self.hasher.finalize();
+        (self.buffer, Blake3Hash::new(*hash.as_bytes()))
+    }
+}
+
+impl Write for HashingBuffer {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.hasher.update(buf);
+        self.buffer.extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Platform-specific compression setting
+#[cfg(target_arch = "wasm32")]
+fn compression_setting() -> Compression {
+    Compression::SNAPPY
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn compression_setting() -> Compression {
+    let level = ZstdLevel::try_new(2).unwrap_or_default();
+    Compression::ZSTD(level)
+}
+
+/// Get shared writer properties (cached)
+///
+/// Configuration optimized for size and query performance:
+/// - Platform-specific compression (Snappy for WASM, ZSTD for native)
+/// - Dictionary encoding enabled
+/// - 32k rows per group by default (configurable)
+/// - OTLP version metadata embedded in file
+pub fn writer_properties() -> &'static WriterProperties {
+    static PROPERTIES: OnceLock<WriterProperties> = OnceLock::new();
+    PROPERTIES.get_or_init(|| {
+        // Embed OTLP version and schema information in Parquet metadata
+        let metadata = vec![
+            KeyValue {
+                key: "otlp.version".to_string(),
+                value: Some("1.5.0".to_string()),
+            },
+            KeyValue {
+                key: "otlp.protocol.version".to_string(),
+                value: Some("v1".to_string()),
+            },
+            KeyValue {
+                key: "otlp2parquet.version".to_string(),
+                value: Some(env!("CARGO_PKG_VERSION").to_string()),
+            },
+            KeyValue {
+                key: "schema.source".to_string(),
+                value: Some("opentelemetry-collector-contrib/clickhouseexporter".to_string()),
+            },
+        ];
+
+        WriterProperties::builder()
+            .set_dictionary_enabled(true)
+            .set_statistics_enabled(EnabledStatistics::Page)
+            .set_compression(compression_setting())
+            .set_data_page_size_limit(256 * 1024)
+            .set_write_batch_size(32 * 1024)
+            .set_max_row_group_size(configured_row_group_size())
+            .set_dictionary_page_size_limit(128 * 1024)
+            .set_key_value_metadata(Some(metadata))
+            .build()
+    })
+}
+
+/// Result of encoding Arrow record batches into Parquet bytes.
+pub struct EncodedParquet {
+    pub bytes: Vec<u8>,
+    pub hash: Blake3Hash,
+    pub schema: SchemaRef,
+    pub parquet_metadata: Arc<ParquetMetaData>,
+    pub row_count: i64,
+}
+
+/// Encode one or more record batches into Parquet bytes using the provided writer properties.
+pub fn encode_record_batches(
+    batches: &[RecordBatch],
+    properties: &WriterProperties,
+) -> Result<EncodedParquet> {
+    if batches.is_empty() {
+        return Err(anyhow!("cannot encode empty batch list"));
+    }
+
+    let mut sink = HashingBuffer::new();
+    let schema: SchemaRef = batches[0].schema();
+
+    let file_metadata = {
+        let mut writer = ArrowWriter::try_new(&mut sink, schema.clone(), Some(properties.clone()))
+            .map_err(|e| anyhow!("failed to create Arrow writer: {}", e))?;
+
+        for batch in batches {
+            if batch.schema() != schema {
+                return Err(anyhow!("all batches must share the same schema"));
+            }
+            writer
+                .write(batch)
+                .map_err(|e| anyhow!("failed to write batch: {}", e))?;
+        }
+
+        writer
+            .close()
+            .map_err(|e| anyhow!("failed to close writer: {}", e))?
+    };
+
+    let (buffer, hash) = sink.finish();
+
+    let parquet_metadata = Arc::new(
+        build_parquet_metadata(file_metadata)
+            .map_err(|e| anyhow!("failed to reconstruct parquet metadata: {}", e))?,
+    );
+    let row_count = parquet_metadata.file_metadata().num_rows();
+
+    Ok(EncodedParquet {
+        bytes: buffer,
+        hash,
+        schema,
+        parquet_metadata,
+        row_count,
+    })
+}
+
+fn build_parquet_metadata(file_metadata: ThriftFileMetaData) -> Result<ParquetMetaData> {
+    let schema = types::from_thrift(&file_metadata.schema)
+        .map_err(|e| anyhow!("failed to decode parquet schema: {}", e))?;
+    let schema_descr = Arc::new(SchemaDescriptor::new(schema));
+
+    let column_orders = parse_column_orders(file_metadata.column_orders, &schema_descr)?;
+
+    let mut row_groups = Vec::with_capacity(file_metadata.row_groups.len());
+    for row_group in file_metadata.row_groups {
+        let metadata = RowGroupMetaData::from_thrift(schema_descr.clone(), row_group)
+            .map_err(|e| anyhow!("failed to decode row group metadata: {}", e))?;
+        row_groups.push(metadata);
+    }
+
+    let physical_metadata = PhysicalFileMetaData::new(
+        file_metadata.version,
+        file_metadata.num_rows,
+        file_metadata.created_by,
+        file_metadata.key_value_metadata,
+        schema_descr,
+        column_orders,
+    );
+
+    Ok(ParquetMetaData::new(physical_metadata, row_groups))
+}
+
+fn parse_column_orders(
+    orders: Option<Vec<TColumnOrder>>,
+    schema_descr: &SchemaDescriptor,
+) -> Result<Option<Vec<ColumnOrder>>> {
+    match orders {
+        Some(order_defs) => {
+            if order_defs.len() != schema_descr.num_columns() {
+                return Err(anyhow!("column order length mismatch"));
+            }
+
+            let mut parsed = Vec::with_capacity(order_defs.len());
+            for (idx, column) in schema_descr.columns().iter().enumerate() {
+                match &order_defs[idx] {
+                    TColumnOrder::TYPEORDER(_) => {
+                        let sort_order = ColumnOrder::get_sort_order(
+                            column.logical_type(),
+                            column.converted_type(),
+                            column.physical_type(),
+                        );
+                        parsed.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
+                    }
+                }
+            }
+            Ok(Some(parsed))
+        }
+        None => Ok(None),
+    }
+}

--- a/crates/otlp2parquet-core/src/parquet/mod.rs
+++ b/crates/otlp2parquet-core/src/parquet/mod.rs
@@ -1,0 +1,5 @@
+pub mod encoding;
+
+pub use encoding::{
+    encode_record_batches, set_parquet_row_group_size, writer_properties, EncodedParquet,
+};

--- a/crates/otlp2parquet-iceberg/Cargo.toml
+++ b/crates/otlp2parquet-iceberg/Cargo.toml
@@ -11,7 +11,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_bytes = "0.11"
 arrow = { workspace = true }
-parquet = { workspace = true, features = ["arrow"] }
+parquet = { workspace = true, features = ["arrow", "zstd"] }
 opendal = { version = "0.54", default-features = false }
 tracing = { workspace = true }
 chrono = { workspace = true }

--- a/crates/otlp2parquet-iceberg/src/init.rs
+++ b/crates/otlp2parquet-iceberg/src/init.rs
@@ -81,6 +81,11 @@ pub async fn initialize_committer() -> InitResult {
         }
     };
 
+    initialize_committer_with_config(config).await
+}
+
+/// Initialize Iceberg committer from an explicit configuration object.
+pub async fn initialize_committer_with_config(config: IcebergRestConfig) -> InitResult {
     // Parse namespace (convert Vec<String> to NamespaceIdent)
     let namespace = match NamespaceIdent::from_vec(config.namespace.clone()) {
         Ok(ns) => ns,

--- a/crates/otlp2parquet-iceberg/src/lib.rs
+++ b/crates/otlp2parquet-iceberg/src/lib.rs
@@ -17,6 +17,7 @@ pub mod http;
 pub mod init;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod manifest;
+mod path;
 pub mod protocol;
 pub mod types;
 pub mod validation;

--- a/crates/otlp2parquet-iceberg/src/path.rs
+++ b/crates/otlp2parquet-iceberg/src/path.rs
@@ -1,0 +1,30 @@
+use url::Url;
+
+/// Join a table location with a relative suffix to produce the catalog-visible path.
+pub fn catalog_path(base_location: &str, suffix: &str) -> String {
+    let base = base_location.trim_end_matches('/');
+    let suffix = suffix.trim_start_matches('/');
+    if base.is_empty() {
+        suffix.to_string()
+    } else if suffix.is_empty() {
+        base.to_string()
+    } else {
+        format!("{}/{}", base, suffix)
+    }
+}
+
+/// Convert an absolute URI-style path into the storage-relative key expected by OpenDAL.
+pub fn storage_key_from_path(path: &str) -> String {
+    if let Ok(url) = Url::parse(path) {
+        let key = url.path().trim_start_matches('/').to_string();
+        if key.is_empty() {
+            // For schemes where the path component is empty, fall back to host if present.
+            if let Some(host) = url.host_str() {
+                return host.to_string();
+            }
+        }
+        key
+    } else {
+        path.trim_start_matches('/').to_string()
+    }
+}

--- a/crates/otlp2parquet-iceberg/src/writer_test.rs
+++ b/crates/otlp2parquet-iceberg/src/writer_test.rs
@@ -150,7 +150,9 @@ async fn test_write_parquet_to_memory() {
         RecordBatch::try_new(schema, vec![Arc::new(Int64Array::from(vec![1, 2, 3]))]).unwrap();
 
     // Act
-    let result = writer.write_parquet("test/file.parquet", &batch).await;
+    let result = writer
+        .write_parquet("test/file.parquet", "test/file.parquet", &batch)
+        .await;
 
     // Assert
     assert!(result.is_ok());
@@ -253,7 +255,7 @@ async fn test_build_data_file() {
 
     // Write the batch to get a ParquetWriteResult
     let write_result = writer
-        .write_parquet("test/file.parquet", &batch)
+        .write_parquet("test/file.parquet", "test/file.parquet", &batch)
         .await
         .unwrap();
 

--- a/crates/otlp2parquet-storage/src/lib.rs
+++ b/crates/otlp2parquet-storage/src/lib.rs
@@ -24,7 +24,8 @@ pub use otlp2parquet_iceberg as iceberg;
 
 // Re-export commonly used types
 pub use opendal_storage::OpenDalStorage;
+pub use otlp2parquet_core::parquet::{set_parquet_row_group_size, writer_properties};
 pub use otlp2parquet_core::{Blake3Hash, ParquetWriteResult};
 #[cfg(feature = "iceberg")]
 pub use otlp2parquet_iceberg::{IcebergCatalog, IcebergCommitter};
-pub use parquet_writer::{set_parquet_row_group_size, writer_properties, ParquetWriter};
+pub use parquet_writer::ParquetWriter;

--- a/crates/otlp2parquet-storage/src/parquet_writer.rs
+++ b/crates/otlp2parquet-storage/src/parquet_writer.rs
@@ -3,134 +3,13 @@
 // Serializes Arrow RecordBatches, computes a Blake3 content hash while
 // encoding, and uploads the resulting Parquet bytes to OpenDAL storage.
 
-use anyhow::{anyhow, bail, Context, Result};
-use arrow::array::RecordBatch;
-use arrow::datatypes::SchemaRef;
+use anyhow::{bail, Context, Result};
+use arrow::record_batch::RecordBatch;
 use chrono::Utc;
 use opendal::Operator;
+use otlp2parquet_core::parquet::{encode_record_batches, writer_properties};
 use otlp2parquet_core::{Blake3Hash, ParquetWriteResult};
-use parquet::basic::ColumnOrder;
-use parquet::file::metadata::{
-    FileMetaData as PhysicalFileMetaData, ParquetMetaData, RowGroupMetaData,
-};
-use parquet::file::properties::{EnabledStatistics, WriterProperties};
-use parquet::format::{ColumnOrder as TColumnOrder, FileMetaData as ThriftFileMetaData, KeyValue};
-use parquet::schema::types::{self, SchemaDescriptor};
-use std::io::{self, Write};
-use std::sync::{Arc, OnceLock};
-
-#[cfg(target_arch = "wasm32")]
-use parquet::basic::Compression;
-#[cfg(not(target_arch = "wasm32"))]
-use parquet::basic::{Compression, ZstdLevel};
-
-const DEFAULT_ROW_GROUP_SIZE: usize = 32 * 1024;
-static ROW_GROUP_SIZE: OnceLock<usize> = OnceLock::new();
-
-/// Configure the global Parquet row group size used by Arrow writers.
-///
-/// Must be called before the first Parquet writer is created. Subsequent calls
-/// are ignored to preserve the existing writer properties cache.
-pub fn set_parquet_row_group_size(row_group_size: usize) {
-    if row_group_size == 0 {
-        return;
-    }
-
-    let _ = ROW_GROUP_SIZE.set(row_group_size);
-}
-
-fn configured_row_group_size() -> usize {
-    ROW_GROUP_SIZE
-        .get()
-        .copied()
-        .unwrap_or(DEFAULT_ROW_GROUP_SIZE)
-}
-
-struct HashingBuffer {
-    buffer: Vec<u8>,
-    hasher: blake3::Hasher,
-}
-
-impl HashingBuffer {
-    fn new() -> Self {
-        Self {
-            buffer: Vec::new(),
-            hasher: blake3::Hasher::new(),
-        }
-    }
-
-    fn finish(self) -> (Vec<u8>, Blake3Hash) {
-        let hash = self.hasher.finalize();
-        (self.buffer, Blake3Hash::new(*hash.as_bytes()))
-    }
-}
-
-impl Write for HashingBuffer {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.hasher.update(buf);
-        self.buffer.extend_from_slice(buf);
-        Ok(buf.len())
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        Ok(())
-    }
-}
-
-/// Platform-specific compression setting
-#[cfg(target_arch = "wasm32")]
-fn compression_setting() -> Compression {
-    Compression::SNAPPY
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-fn compression_setting() -> Compression {
-    let level = ZstdLevel::try_new(2).unwrap_or_default();
-    Compression::ZSTD(level)
-}
-
-/// Get shared writer properties (cached)
-///
-/// Configuration optimized for size and query performance:
-/// - Platform-specific compression (Snappy for WASM, ZSTD for native)
-/// - Dictionary encoding enabled
-/// - 32k rows per group by default (configurable)
-/// - OTLP version metadata embedded in file
-pub fn writer_properties() -> &'static WriterProperties {
-    static PROPERTIES: OnceLock<WriterProperties> = OnceLock::new();
-    PROPERTIES.get_or_init(|| {
-        // Embed OTLP version and schema information in Parquet metadata
-        let metadata = vec![
-            KeyValue {
-                key: "otlp.version".to_string(),
-                value: Some("1.5.0".to_string()),
-            },
-            KeyValue {
-                key: "otlp.protocol.version".to_string(),
-                value: Some("v1".to_string()),
-            },
-            KeyValue {
-                key: "otlp2parquet.version".to_string(),
-                value: Some(env!("CARGO_PKG_VERSION").to_string()),
-            },
-            KeyValue {
-                key: "schema.source".to_string(),
-                value: Some("opentelemetry-collector-contrib/clickhouseexporter".to_string()),
-            },
-        ];
-
-        WriterProperties::builder()
-            .set_dictionary_enabled(true)
-            .set_statistics_enabled(EnabledStatistics::Page)
-            .set_compression(compression_setting())
-            .set_data_page_size_limit(256 * 1024) // 256 KiB data pages
-            .set_write_batch_size(32 * 1024)
-            .set_max_row_group_size(configured_row_group_size()) // Configurable row group size
-            .set_dictionary_page_size_limit(128 * 1024)
-            .set_key_value_metadata(Some(metadata))
-            .build()
-    })
-}
+use std::io::Write;
 
 /// Parquet writer that streams directly to OpenDAL storage
 pub struct ParquetWriter {
@@ -200,27 +79,16 @@ impl ParquetWriter {
             bail!("Cannot write empty batch list");
         }
 
-        let mut sink = HashingBuffer::new();
-        let props = writer_properties().clone();
-        let schema: SchemaRef = batches[0].schema();
-        let file_metadata = {
-            let mut writer =
-                parquet::arrow::ArrowWriter::try_new(&mut sink, schema.clone(), Some(props))?;
-
-            for batch in batches {
-                writer.write(batch)?;
-            }
-            writer.close()?
-        };
-
-        let (buffer, hash) = sink.finish();
-        let file_size = buffer.len() as u64;
-
-        let parquet_metadata = Arc::new(
-            build_parquet_metadata(file_metadata)
-                .context("failed to reconstruct parquet metadata from writer")?,
-        );
-        let row_count = parquet_metadata.file_metadata().num_rows();
+        let encoded = encode_record_batches(batches, writer_properties())
+            .context("failed to encode record batches to parquet")?;
+        let otlp2parquet_core::parquet::EncodedParquet {
+            bytes,
+            hash,
+            schema,
+            parquet_metadata,
+            row_count,
+        } = encoded;
+        let file_size = bytes.len() as u64;
         let completed_at = Utc::now();
 
         // Generate partition path with signal type
@@ -233,7 +101,7 @@ impl ParquetWriter {
         );
 
         // Write to storage
-        self.operator.write(&path, buffer).await?;
+        self.operator.write(&path, bytes).await?;
 
         Ok(ParquetWriteResult {
             path,
@@ -244,61 +112,6 @@ impl ParquetWriter {
             parquet_metadata,
             completed_at,
         })
-    }
-}
-
-fn build_parquet_metadata(file_metadata: ThriftFileMetaData) -> Result<ParquetMetaData> {
-    let schema = types::from_thrift(&file_metadata.schema)
-        .map_err(|e| anyhow!("failed to decode parquet schema: {}", e))?;
-    let schema_descr = Arc::new(SchemaDescriptor::new(schema));
-
-    let column_orders = parse_column_orders(file_metadata.column_orders, &schema_descr)?;
-
-    let mut row_groups = Vec::with_capacity(file_metadata.row_groups.len());
-    for row_group in file_metadata.row_groups {
-        let metadata = RowGroupMetaData::from_thrift(schema_descr.clone(), row_group)
-            .map_err(|e| anyhow!("failed to decode row group metadata: {}", e))?;
-        row_groups.push(metadata);
-    }
-
-    let physical_metadata = PhysicalFileMetaData::new(
-        file_metadata.version,
-        file_metadata.num_rows,
-        file_metadata.created_by,
-        file_metadata.key_value_metadata,
-        schema_descr,
-        column_orders,
-    );
-
-    Ok(ParquetMetaData::new(physical_metadata, row_groups))
-}
-
-fn parse_column_orders(
-    orders: Option<Vec<TColumnOrder>>,
-    schema_descr: &SchemaDescriptor,
-) -> Result<Option<Vec<ColumnOrder>>> {
-    match orders {
-        Some(order_defs) => {
-            if order_defs.len() != schema_descr.num_columns() {
-                return Err(anyhow!("column order length mismatch"));
-            }
-
-            let mut parsed = Vec::with_capacity(order_defs.len());
-            for (idx, column) in schema_descr.columns().iter().enumerate() {
-                match &order_defs[idx] {
-                    TColumnOrder::TYPEORDER(_) => {
-                        let sort_order = ColumnOrder::get_sort_order(
-                            column.logical_type(),
-                            column.converted_type(),
-                            column.physical_type(),
-                        );
-                        parsed.push(ColumnOrder::TYPE_DEFINED_ORDER(sort_order));
-                    }
-                }
-            }
-            Ok(Some(parsed))
-        }
-        None => Ok(None),
     }
 }
 
@@ -329,19 +142,10 @@ pub fn write_batches_with_hash(batches: Vec<RecordBatch>) -> Result<(Vec<u8>, Bl
         bail!("Cannot write empty batch list");
     }
 
-    let mut sink = HashingBuffer::new();
-    let props = writer_properties().clone();
-    {
-        let mut writer =
-            parquet::arrow::ArrowWriter::try_new(&mut sink, batches[0].schema(), Some(props))?;
+    let encoded = encode_record_batches(&batches, writer_properties())
+        .context("failed to encode record batches to parquet")?;
 
-        for batch in batches {
-            writer.write(&batch)?;
-        }
-        let _ = writer.close()?;
-    }
-
-    Ok(sink.finish())
+    Ok((encoded.bytes, encoded.hash))
 }
 
 #[cfg(test)]

--- a/docs/developers/iceberg_quality_review.md
+++ b/docs/developers/iceberg_quality_review.md
@@ -1,0 +1,29 @@
+# Iceberg integration quality review
+
+## Summary
+- Normalized Iceberg data, manifest, and manifest-list paths to storage-relative keys so OpenDAL writes land in the warehouse layout expected by the catalog.【F:crates/otlp2parquet-iceberg/src/writer.rs†L48-L92】【F:crates/otlp2parquet-iceberg/src/manifest.rs†L56-L123】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L508-L555】
+- Reused the shared Parquet encoder from `otlp2parquet-core` so Iceberg commits inherit the same compression, hashing, and metadata tuning as the plain S3 writer.【F:crates/otlp2parquet-core/src/parquet/encoding.rs†L15-L148】【F:crates/otlp2parquet-iceberg/src/writer.rs†L94-L151】【F:crates/otlp2parquet-storage/src/parquet_writer.rs†L12-L96】
+- Reduced Iceberg REST logging to debug-level snapshots and truncated payload excerpts, preventing multi-kilobyte table schemas from flooding production logs.【F:crates/otlp2parquet-iceberg/src/catalog.rs†L214-L249】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L270-L318】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L363-L405】
+- Added an explicit `initialize_committer_with_config` path and plumbed runtime configuration through the server and Lambda entry points so deployments no longer need to duplicate Iceberg settings in two env namespaces.【F:crates/otlp2parquet-iceberg/src/init.rs†L72-L133】【F:crates/otlp2parquet-server/src/lib.rs†L20-L95】【F:crates/otlp2parquet-lambda/src/lib.rs†L10-L134】
+- Removed manual table metadata fabrication—every write now consults the catalog after table creation attempts to honor catalog-managed locations.【F:crates/otlp2parquet-iceberg/src/writer.rs†L104-L157】
+
+## Detailed updates
+
+### 1. Storage paths now align with OpenDAL semantics
+`IcebergWriter::generate_warehouse_path` now builds catalog paths with a helper that strips schemes, and `write_parquet` sends the storage-relative key to OpenDAL while preserving the catalog URI for Iceberg metadata. Manifest and manifest-list writers use the same helpers, and catalog commits stat files with relative keys to avoid zero-byte entries.【F:crates/otlp2parquet-iceberg/src/writer.rs†L48-L151】【F:crates/otlp2parquet-iceberg/src/manifest.rs†L56-L123】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L508-L555】
+
+### 2. Shared Parquet encoding
+A new `otlp2parquet_core::parquet` module encapsulates the hashing buffer, writer properties, and metadata reconstruction. Both the storage writer and the Iceberg writer consume the same encoder, guaranteeing identical compression, row-group sizing, and metadata for every Parquet file regardless of commit path.【F:crates/otlp2parquet-core/src/parquet/encoding.rs†L15-L148】【F:crates/otlp2parquet-storage/src/parquet_writer.rs†L12-L96】【F:crates/otlp2parquet-iceberg/src/writer.rs†L118-L151】
+
+### 3. Calmer REST logging
+Create, load, and update operations now log payloads only at `debug!` and trim error bodies to 500 bytes, eliminating noisy info/warn logs while retaining diagnostics when debugging is enabled.【F:crates/otlp2parquet-iceberg/src/catalog.rs†L214-L249】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L270-L318】【F:crates/otlp2parquet-iceberg/src/catalog.rs†L363-L405】
+
+### 4. Configuration-driven initialization
+`initialize_committer_with_config` allows runtimes to supply parsed `RuntimeConfig.iceberg` values directly. The server and Lambda adapters convert their runtime configuration into `IcebergRestConfig`, so deployments defined in TOML/ENV are honored without duplicating variables.【F:crates/otlp2parquet-iceberg/src/init.rs†L72-L133】【F:crates/otlp2parquet-server/src/lib.rs†L86-L139】【F:crates/otlp2parquet-lambda/src/lib.rs†L104-L173】
+
+### 5. Catalog metadata is authoritative
+`get_or_create_table` first attempts to load table metadata and, after any create attempt (including 409 conflicts), reloads the catalog instead of fabricating locations. This ensures Iceberg commits always use catalog-managed warehouse paths.【F:crates/otlp2parquet-iceberg/src/writer.rs†L104-L157】
+
+## Remaining considerations
+- The new path helpers currently operate on basic URI patterns; add integration tests for alternative catalog schemes (e.g., WASBS, GCS) to validate parsing edge cases.
+- Consider exposing structured logging toggles so operators can opt into verbose REST traces without recompiling.


### PR DESCRIPTION
## Summary
- share the parquet encoding pipeline from otlp2parquet-core so Iceberg and plain S3 writers emit consistent files
- normalize Iceberg data and metadata paths to storage-relative keys and trim REST logging noise
- respect runtime Iceberg configuration across server and Lambda while updating developer documentation

## Testing
- `cargo test -p otlp2parquet-iceberg`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f92eb41a4832e9fed37e74857117a)