### PR TITLE
build(deps): bump toml and related dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,9 +2741,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
+checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
 dependencies = [
  "serde_core",
 ]
@@ -3139,9 +3139,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "399b1124a3c9e16766831c6bba21e50192572cdd98706ea114f9502509686ffc"
+checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
 dependencies = [
  "serde_core",
  "serde_spanned",
@@ -3152,18 +3152,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.0.0+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
+checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.9+spec-1.1.0"
+version = "1.1.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
+checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
 dependencies = [
  "winnow",
 ]
@@ -3884,9 +3884,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.15"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
 
 [[package]]
 name = "wit-bindgen"


### PR DESCRIPTION
## Summary
- Consolidates dependabot PR #121 (toml 1.0.6 → 1.0.7) by updating to the latest semver-compatible versions
- **toml**: 1.0.6+spec-1.1.0 → 1.1.0+spec-1.1.0
- **toml_parser**: 1.0.9+spec-1.1.0 → 1.1.0+spec-1.1.0
- **toml_datetime**: 1.0.0+spec-1.1.0 → 1.1.0+spec-1.1.0
- **serde_spanned**: 1.0.4 → 1.1.0
- **winnow**: 0.7.15 → 1.0.0

All versions remain within the `"1.0"` semver range specified in Cargo.toml. Only `Cargo.lock` is changed.

## Test plan
- [x] `make build-cli` — compiles successfully
- [x] `make clippy` — zero warnings
- [x] `make test` — all 24 unit tests pass
- [ ] CI should pass on this PR

Closes #121

https://claude.ai/code/session_019vfE5g4RTSzpoXnJnP2qBA